### PR TITLE
Add AGENTS.md for cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ Note: The `composer.json` `cs-check` script targets `src/` which does not exist 
 ### Build
 
 ```bash
-make pkg_balancirk.zip
+make -B
 ```
 
-This builds the full installable Joomla package zip (including sub-packages for the component and plugin).
+This forces a full rebuild of the installable Joomla package zip (including sub-packages for the component and plugin). The `-B` flag unconditionally rebuilds all targets.
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Balancirk - Joomla 4 Extension
+
+## Overview
+
+Balancirk is a Joomla 4 extension package for managing members, students, lessons, subscriptions, and attendance for a gymnastics/circus school. It consists of:
+
+- **com_balancirk** — Main Joomla MVC component (admin + site + API)
+- **plg_webservices_balancirk** — Web services plugin (REST API routes)
+- **joomlaology** — Shared PHP utility library
+
+This is NOT a standalone application. It requires installation into a Joomla 4 CMS instance.
+
+## Cursor Cloud specific instructions
+
+### Prerequisites (installed by update script)
+
+- PHP 8.3+ with extensions: cli, xml, mbstring, tokenizer, zip
+- Composer (for phpcs dev dependency)
+- GNU Make + zip (for building packages)
+
+### Lint
+
+```bash
+./vendor/bin/phpcs --standard=PSR12 components/ plugins/ libraries/
+```
+
+Note: The `composer.json` `cs-check` script targets `src/` which does not exist at root level. Use the command above to lint actual source directories.
+
+### Build
+
+```bash
+make pkg_balancirk.zip
+```
+
+This builds the full installable Joomla package zip (including sub-packages for the component and plugin).
+
+### Testing
+
+There are no automated unit/integration tests in this repository. Validation is done via:
+1. `phpcs` linting (PSR-12 standard)
+2. Building the package zip successfully
+3. Installing into a Joomla 4 instance (external)
+
+### Important notes
+
+- The `vendor/` directory is committed to the repo, so `composer install` is fast (no network needed if lock file matches).
+- The `debug` target in `components/com_balancirk/Makefile` deploys to a remote server via SSH — do not use it in cloud environments.
+- Built artifacts (`pkg_balancirk.zip`, `packages/*.zip`) are also committed to the repo; `make` rebuilds them fresh.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this repository.

### What's included

- Overview of the project structure (Joomla 4 extension package)
- Lint command (`phpcs --standard=PSR12`)
- Build command (`make pkg_balancirk.zip`)
- Important notes about the development workflow

### Development environment verified

| Check | Command | Result |
|-------|---------|--------|
| PHP | `php --version` | PHP 8.3.6 |
| Composer | `composer --version` | Composer 2.9.8 |
| Lint | `./vendor/bin/phpcs --standard=PSR12 components/ plugins/ libraries/` | Runs successfully (finds existing style issues) |
| Build | `make pkg_balancirk.zip` | Produces pkg_balancirk.zip (233KB) |

### Evidence

[dev_environment_output.log](https://cursor.com/artifacts/c/art-2f967aee-ce4c-451e-b48b-46aa2f0bbbcf)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e05e109e-b15a-45e3-9ca3-8bcee89aae80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e05e109e-b15a-45e3-9ca3-8bcee89aae80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

