### PR TITLE
Add Joomla 6 compatibility

### DIFF
--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -112,4 +112,22 @@
 			version="4.*" />
 		<php_minimum>8.1</php_minimum>
 	</update>
+	<update>
+		<name>com_balancirk</name>
+		<description>This is the balancirk plugin</description>
+		<element>com_balancirk</element>
+		<type>package</type>
+		<version>1.3.0</version>
+		<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
+		<infourl title="agosms">https://github.com/kriscox/Joomla-extension-balancirk/blob/master/README.md</infourl>
+		<downloads>
+			<downloadurl type="full"
+				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.0/pkg_balancirk.zip</downloadurl>
+		</downloads>
+		<maintainer>CoCoCo</maintainer>
+		<maintainerurl>http://www.cococo.be</maintainerurl>
+		<targetplatform name="joomla"
+			version="(4|5|6)\." />
+		<php_minimum>8.1</php_minimum>
+	</update>
 </updates>

--- a/components/com_balancirk/admin/src/Extension/BalancirkComponent.php
+++ b/components/com_balancirk/admin/src/Extension/BalancirkComponent.php
@@ -10,7 +10,7 @@
 
 namespace CoCoCo\Component\Balancirk\Administrator\Extension;
 
-defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\Router\RouterServiceInterface;

--- a/components/com_balancirk/admin/src/Model/MembersModel.php
+++ b/components/com_balancirk/admin/src/Model/MembersModel.php
@@ -181,7 +181,7 @@ class MembersModel extends ListModel
             }
 
             // remove addition information from user
-            $dbo = $this->getDbo();
+            $dbo = $this->getDatabase();
             $query = $dbo->getQuery(true)->delete($dbo->quoteName('#__balancirk_members_additional'));
 
             $conditions = array(

--- a/components/com_balancirk/admin/src/Model/StudentModel.php
+++ b/components/com_balancirk/admin/src/Model/StudentModel.php
@@ -73,7 +73,7 @@ class StudentModel extends AdminModel
      * 
      * @param   integer  $pk  The id of the item.
      * 
-     * @return  CMSObject|boolean  Object on success, false on failure.
+     * @return  \stdClass|boolean  Object on success, false on failure.
      * 
      * @since   __BUMP_VERSION__
      */

--- a/components/com_balancirk/admin/src/Model/SubscriptionModel.php
+++ b/components/com_balancirk/admin/src/Model/SubscriptionModel.php
@@ -246,7 +246,7 @@ Het Balancirk team');
      *
      * @param   integer  $pk  The id of the primary key.
      *
-     * @return  CMSObject|boolean  Object on success, false on failure.
+     * @return  \stdClass|boolean  Object on success, false on failure.
      *
      * @since   __BUMP_VERIONS__
      */

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -9,7 +9,7 @@
 	<authorUrl>https://cococo.be</authorUrl>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.2.10</version>
+	<version>1.3.0</version>
 	<description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- This is the PHP namespace under which the extension's

--- a/components/com_balancirk/script.php
+++ b/components/com_balancirk/script.php
@@ -11,7 +11,6 @@
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\Table\Table;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Installer\InstallerScript;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel as ModelLegacy;
@@ -241,7 +240,9 @@ class Com_BalancirkInstallerScript extends InstallerScript
             return;
         }
 
-        $menuType = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($db);
+        $menuType = Factory::getApplication()->bootComponent('menus')
+            ->getMVCFactory()
+            ->createTable('MenuType', 'Administrator');
 
         $menuType->menutype = 'hiddenmenu';
         $menuType->title = 'Hidden Menu';

--- a/components/com_balancirk/script.php
+++ b/components/com_balancirk/script.php
@@ -225,7 +225,6 @@ class Com_BalancirkInstallerScript extends InstallerScript
 
     public function addHiddenMenu()
     {
-
         /** @var \Joomla\Database\DatabaseDriver $db */
         $db = Factory::getContainer()->get('DatabaseDriver');
 
@@ -239,12 +238,10 @@ class Com_BalancirkInstallerScript extends InstallerScript
 
         if ($existing)
         {
-            return; // Already exists
+            return;
         }
 
-        //Load the menu type table
-        Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/tables');
-        $menuType = Table::getInstance('MenuType', 'MenusTable');
+        $menuType = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($db);
 
         $menuType->menutype = 'hiddenmenu';
         $menuType->title = 'Hidden Menu';

--- a/components/com_balancirk/site/src/Model/TeacherModel.php
+++ b/components/com_balancirk/site/src/Model/TeacherModel.php
@@ -66,17 +66,17 @@ class TeacherModel extends BaseDatabaseModel
 					'lesson'
 				]
 			))
-			->from($this->db->quoteName('#__balancirk_teached', 't'))
+			->from($db->quoteName('#__balancirk_teached', 't'))
 			->join(
 				'INNER',
-				$this->db->quoteName('#__balancirk_lessons', 'l'),
-				$this->db->quoteName('t.lesson') . ' = ' . $this->db->quoteName('l.id')
+				$db->quoteName('#__balancirk_lessons', 'l'),
+				$db->quoteName('t.lesson') . ' = ' . $db->quoteName('l.id')
 			)
-			->where($this->db->quoteName('teacher') . ' = ' . (int) $teacherId)
-			->where($this->db->quoteName('date') . ' BETWEEN ' . $this->db->quote($startDate) . ' AND ' . $this->db->quote($endDate));
+			->where($db->quoteName('teacher') . ' = ' . (int) $teacherId)
+			->where($db->quoteName('date') . ' BETWEEN ' . $db->quote($startDate) . ' AND ' . $db->quote($endDate));
 
-		$this->db->setQuery($query);
-		return $this->db->loadObjectList();
+		$db->setQuery($query);
+		return $db->loadObjectList();
 	}
 
 	/**

--- a/libraries/joomlaology/traits/ApiTools.php
+++ b/libraries/joomlaology/traits/ApiTools.php
@@ -122,7 +122,7 @@ trait ApiTools
      */
     protected function prepareSqlFieldsArray($data)
     {
-        $db = $this->getDbo();
+        $db = $this->getDatabase();
         $fields = array();
 
         if (gettype($data) == 'object') {

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.2.9</version>
+	<version>1.3.0</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->

--- a/plugins/balancirk/balancirk.xml
+++ b/plugins/balancirk/balancirk.xml
@@ -9,7 +9,7 @@
     <authorUrl>https://cococo.be</authorUrl>
     <copyright>CoCoCo</copyright>
     <license>GPL v2</license>
-    <version>0.0.1</version>
+    <version>1.3.0</version>
     <description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
     <files>
         <filename plugin="balancirk">balancirk.php</filename>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the Balancirk extension natively compatible with Joomla 6 (without requiring the Backward Compatibility 6 plugin) while maintaining full backward compatibility with Joomla 5. Bumps version to 1.3.0.

## Changes

### Removed deprecated APIs (removed in Joomla 6)

| File | Change |
|------|--------|
| `BalancirkComponent.php` | `JPATH_PLATFORM` → `_JEXEC` |
| `SubscriptionModel.php` | Removed `use Joomla\CMS\Object\CMSObject`, updated `@return` docblock to `\stdClass` |
| `StudentModel.php` | Updated `@return` docblock from `CMSObject` to `\stdClass` |
| `script.php` | Replaced `ModelLegacy::getInstance()` + `JFactory` with `bootComponent()->getMVCFactory()->createModel()` |
| `script.php` | Replaced `Table::getInstance()` with `bootComponent()->getMVCFactory()->createTable()` |
| `MembersModel.php` | Replaced `getDbo()` with `getDatabase()` |
| `TeacherModel.php` | Replaced `$this->db` property with local `$db` from `getDatabase()` |
| `ApiTools.php` | Replaced `$this->app` with `$this->getApplication()`, `$this->getDbo()` with `$this->getDatabase()` |

### Version & metadata

- Bumped package version to **1.3.0** (`pkg_balancirk.xml`, `balancirk.xml`, plugin `balancirk.xml`)
- Added update server entry targeting Joomla `(4|5|6)\.` with PHP minimum 8.1

## Backward compatibility

All replacement APIs used (`_JEXEC`, `getDatabase()`, `getApplication()`, `bootComponent()->getMVCFactory()`) are available since Joomla 4.0/4.2, ensuring full compatibility with Joomla 4, 5, and 6.

## Joomla 6 breaking changes addressed

Per the [official migration guide](https://manual.joomla.org/migrations/54-60/removed-backward-incompatibility/):

- `JPATH_PLATFORM` constant removed
- `CMSObject` removed from core models' `getItem()` return type
- `Table::getInstance()` deprecated in favor of MVCFactory approach
- `$this->app` removed from plugins
- `getDbo()` deprecated in favor of `getDatabase()`
- `ModelLegacy::getInstance()` and `addIncludePath()` removed

## Testing

- ✅ `php -l` — All modified files pass syntax check
- ✅ `make -B` — Package builds successfully
- ✅ `phpcs --standard=PSR12` — No new lint errors introduced

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e05e109e-b15a-45e3-9ca3-8bcee89aae80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e05e109e-b15a-45e3-9ca3-8bcee89aae80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

