### PR TITLE
Fix student lesson lookup for subscriptions

### DIFF
--- a/components/com_balancirk/site/src/Model/SubscriptionModel.php
+++ b/components/com_balancirk/site/src/Model/SubscriptionModel.php
@@ -166,6 +166,27 @@ class SubscriptionModel extends AdminModel
     }
 
     /**
+     * Method to get lessons open for a specific student.
+     *
+     * @param   int  $studentId  Student id.
+     *
+     * @return  array
+     *
+     * @since   1.2.30
+     */
+    public function getLessonsForStudent(int $studentId): array
+    {
+        if ($studentId <= 0) {
+            return [];
+        }
+
+        /** @var lessonsModel */
+        $model = $this->getMVCFactory()->createModel('Lessons', 'Site');
+
+        return $model->getOpenLessons($studentId);
+    }
+
+    /**
      * Check whether there are lessons with an open registration period.
      *
      * @return  bool


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add the missing site `SubscriptionModel::getLessonsForStudent()` method used by the subscription view.
- Reuse the existing site lessons model filtering so lesson options stay scoped by student eligibility and existing subscriptions.

### Testing
- Warning: `./vendor/bin/phpcs --standard=PSR12 components/ plugins/ libraries/` fails on existing repository-wide PSR-12 violations.
- Passed: `make -B` builds the Joomla package successfully after creating the ignored local `packages/` build directory.
- Passed: `php -l components/com_balancirk/site/src/Model/SubscriptionModel.php` reports no syntax errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bac325b-51c5-4f2e-b069-1b7f204aa0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bac325b-51c5-4f2e-b069-1b7f204aa0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

