### PR TITLE
fix: correct SQL bugs blocking age-column creation on install/upgrade from 1.2.9

### DIFF
--- a/components/com_balancirk/admin/sql/install.mysql.utf8.sql
+++ b/components/com_balancirk/admin/sql/install.mysql.utf8.sql
@@ -169,6 +169,8 @@ SELECT a.`id`,
     a.`state`,
     a.`lesdays`,
     a.`max_students`,
+    a.`min_age`,
+    a.`max_age`,
     (
         SELECT COUNT(*)
         FROM `#__balancirk_subscriptions`
@@ -223,7 +225,9 @@ CREATE TABLE IF NOT EXISTS `#__balancirk_teachers`(
     `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `member` int(11) NOT NULL,
     `lesson` int(11) NOT NULL,
-    UNIQUE (`member`, `les`)
+    UNIQUE (`member`, `lesson`),
+    CONSTRAINT `fk_teachers_lesson` FOREIGN KEY (`lesson`) REFERENCES `#__balancirk_lessons` (`id`),
+    CONSTRAINT `fk_teachers_member` FOREIGN KEY (`member`) REFERENCES `#__balancirk_members_additional` (`id`)
 );
 /**************************************************************************************************
  *                                                                                                 * 

--- a/components/com_balancirk/admin/sql/updates/mysql/1.2.10.sql
+++ b/components/com_balancirk/admin/sql/updates/mysql/1.2.10.sql
@@ -21,9 +21,9 @@ SELECT
     `l`.`state` AS `state`,
     `s`.`subscribed` AS `subscribed`
 FROM
-    `tc_balancirk_subscriptions` `s`
-    JOIN `tc_balancirk_lessons` `l` ON `s`.`lesson` = `l`.`id`
-    JOIN `tc_balancirk_students` `t` ON `s`.`student` = `t`.`id`;
+    `#__balancirk_subscriptions` `s`
+    JOIN `#__balancirk_lessons` `l` ON `s`.`lesson` = `l`.`id`
+    JOIN `#__balancirk_students` `t` ON `s`.`student` = `t`.`id`;
 
 /***********************************************************************************************
 *                                                                                              *
@@ -44,8 +44,8 @@ SELECT
     `s`.`name` AS `naam kind`,
     `st`.`uitpas` AS `uitpas`
 FROM
-    `tc_balancirk_subscriptions_view` `s`
-    JOIN `tc_balancirk_students` `st` ON `s`.`studentid` = `st`.`id`
-    JOIN `tc_balancirk_parents` `p` ON `p`.`child` = `s`.`studentid`
+    `#__balancirk_subscriptions_view` `s`
+    JOIN `#__balancirk_students` `st` ON `s`.`studentid` = `st`.`id`
+    JOIN `#__balancirk_parents` `p` ON `p`.`child` = `s`.`studentid`
     AND `p`.`primary` = 1
-    JOIN `tc_balancirk_members` `m` ON `m`.`id` = `p`.`parent`;
+    JOIN `#__balancirk_members` `m` ON `m`.`id` = `p`.`parent`;

--- a/components/com_balancirk/admin/src/Model/SubscriptionModel.php
+++ b/components/com_balancirk/admin/src/Model/SubscriptionModel.php
@@ -177,7 +177,6 @@ class SubscriptionModel extends AdminModel
         }
 
         $waitinglist = ($model->getNumberOfStudents($lessonId) < $lesson->max_students) ? 0 : 1;
-        array_push($values, $waitinglist);
 
         $db = $this->getDatabase();
         $query = $db->getQuery(true);

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -9,7 +9,7 @@
 	<authorUrl>https://cococo.be</authorUrl>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.0</version>
+	<version>1.3.2</version>
 	<description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- This is the PHP namespace under which the extension's

--- a/components/com_balancirk/site/src/Model/SubscriptionModel.php
+++ b/components/com_balancirk/site/src/Model/SubscriptionModel.php
@@ -250,7 +250,6 @@ class SubscriptionModel extends AdminModel
         }
 
         $waitinglist = ($model->getNumberOfStudents($data['lesson']) < $lesson->max_students) ? 0 : 1;
-        array_push($values, $waitinglist);
 
         $db = $this->getDatabase();
         $query = $db->getQuery(true);

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.0</version>
+	<version>1.3.2</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation of why `min_age`/`max_age` columns were missing on production (after install/upgrade from v1.2.9) and verification of age-filtering and subscription-page lesson filtering.

### Root causes found and fixed

#### 1. `install.mysql.utf8.sql` — wrong UNIQUE constraint in `teachers` table

The `teachers` table was created with `UNIQUE (\`member\`, \`les\`)` but the column was already renamed to `lesson` (a change made in `1.2.9.sql` for existing installs). MySQL raises **error 1072** (`Key column 'les' doesn't exist in table`) on fresh installs, preventing the table from being created. The FK constraints added by `1.2.9.sql` were also missing from the install script.

**Fix:** Change `UNIQUE (\`member\`, \`les\`)` → `UNIQUE (\`member\`, \`lesson\`)` and add the two FK constraints.

#### 2. `install.mysql.utf8.sql` — `lessons_complete` view missing `min_age` / `max_age`

The `#__balancirk_lessons_complete` view was recreated with all columns from the base table *except* the two age columns, even though the `lessons` table definition in the same file already included them. This meant fresh installs had an inconsistent view.

**Fix:** Add `a.\`min_age\`` and `a.\`max_age\`` to the SELECT in the view definition (matching what `1.2.12.sql` already does for upgrades).

#### 3. `1.2.10.sql` — hardcoded `tc_` table prefix breaks upgrades

`subscriptions_view` and `subscriptions_comptable` were (re)created referencing `tc_balancirk_*` instead of `#__balancirk_*`. On any Joomla installation whose database prefix is not `tc_`, MySQL either silently creates broken views or raises an error. When this file fails, Joomla may not advance the schema version past `1.2.9`, stalling the update chain and preventing `1.2.12.sql` (which `ADD COLUMN min_age / max_age`) from ever running.

**Fix:** Replace all `tc_balancirk_*` references with `#__balancirk_*`.

#### 4. Dead code — `array_push($values, $waitinglist)` in both SubscriptionModels

`$values` is never declared anywhere in `add()`. The call produces a PHP warning and has no effect since `$waitinglist` is used directly in the `INSERT` query two lines later. Removed from both `site/src/Model/SubscriptionModel.php` and `admin/src/Model/SubscriptionModel.php`.

---

### Age verification — status: already implemented and working

`LessonAgeHelper::matchesLesson()` computes the student's age at the lesson start date and checks it against `min_age` / `max_age`. This is called:

- In `LessonsModel::getOpenLessonItems()` — filters the lesson dropdown to only show age-appropriate lessons for the selected student.
- In `SubscriptionModel::add()` (site + admin/API) — server-side guard before inserting a subscription row; returns `COM_BALANCIRK_SUBSCRIPTION_AGE_MISMATCH` on failure.

### Subscription-page lesson filtering — status: already implemented and working

When a student is selected on the subscription form:

1. The server renders a `<script type="application/json" id="lessons-by-student">` block with per-student lesson maps (`HtmlView::display()` → `SubscriptionModel::getLessonsForStudent()` → `LessonsModel::getOpenLessons($studentId)`).
2. Inline JS switches the lesson `<select>` contents immediately from the pre-loaded map.
3. `balancirk_subscription_lessons.js` also makes a live AJAX call to `subscription.lessons` (`SubscriptionController::lessons()`) which re-applies age filtering at request time.

Both paths correctly hide lessons the student is not age-eligible for.

---

### Testing

- ✅ `./vendor/bin/phpcs --standard=PSR12 components/ plugins/ libraries/` — no new errors introduced (all remaining warnings are pre-existing).
- ✅ `make -B` — package zip builds successfully.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c5091d7-e04c-45fd-bfd1-bb08403bf0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c5091d7-e04c-45fd-bfd1-bb08403bf0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

