### PR TITLE
fix(sql): repair missing min_age/max_age columns after upgrade from 1.2.9

### DIFF
--- a/components/com_balancirk/admin/sql/updates/mysql/1.2.12.sql
+++ b/components/com_balancirk/admin/sql/updates/mysql/1.2.12.sql
@@ -6,10 +6,11 @@
  *                                                                                                 *
  **************************************************************************************************/
 ALTER TABLE `#__balancirk_lessons`
-ADD COLUMN `min_age` int(11) DEFAULT NULL
-AFTER `max_students`,
-    ADD COLUMN `max_age` int(11) DEFAULT NULL
-AFTER `min_age`;
+    ADD COLUMN `min_age` int(11) DEFAULT NULL AFTER `max_students`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN `max_age` int(11) DEFAULT NULL AFTER `min_age`;
+
 CREATE OR REPLACE VIEW `#__balancirk_lessons_complete` AS
 SELECT a.`id`,
     a.`name`,

--- a/components/com_balancirk/admin/sql/updates/mysql/1.2.20.sql
+++ b/components/com_balancirk/admin/sql/updates/mysql/1.2.20.sql
@@ -6,11 +6,13 @@
  *                                                                                                 *
  **************************************************************************************************/
 ALTER TABLE `#__balancirk_lessons`
-ADD COLUMN `subscription_email_subject` varchar(255) DEFAULT NULL
-AFTER `max_age`,
-    ADD COLUMN `subscription_email_body` text DEFAULT NULL
-AFTER `subscription_email_subject`,
-    ADD COLUMN `waitinglist_email_subject` varchar(255) DEFAULT NULL
-AFTER `subscription_email_body`,
-    ADD COLUMN `waitinglist_email_body` text DEFAULT NULL
-AFTER `waitinglist_email_subject`;
+    ADD COLUMN `subscription_email_subject` varchar(255) DEFAULT NULL AFTER `max_age`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN `subscription_email_body` text DEFAULT NULL AFTER `subscription_email_subject`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN `waitinglist_email_subject` varchar(255) DEFAULT NULL AFTER `subscription_email_body`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN `waitinglist_email_body` text DEFAULT NULL AFTER `waitinglist_email_subject`;

--- a/components/com_balancirk/admin/sql/updates/mysql/1.3.2.sql
+++ b/components/com_balancirk/admin/sql/updates/mysql/1.3.2.sql
@@ -1,0 +1,57 @@
+/**************************************************************************************************
+ *                                                                                                 *
+ *  Repair script: ensure min_age/max_age and email template columns exist on lessons table.       *
+ *                                                                                                 *
+ *  The original 1.2.12 and 1.2.20 ALTER TABLE statements combined multiple ADD COLUMN clauses     *
+ *  where later clauses referenced columns added earlier in the same statement. This can fail      *
+ *  on certain MariaDB/MySQL versions. This script safely re-adds all potentially missing          *
+ *  columns for sites that upgraded through the broken scripts.                                    *
+ *                                                                                                 *
+ **************************************************************************************************/
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `min_age` int(11) DEFAULT NULL AFTER `max_students`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `max_age` int(11) DEFAULT NULL AFTER `min_age`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `subscription_email_subject` varchar(255) DEFAULT NULL AFTER `max_age`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `subscription_email_body` text DEFAULT NULL AFTER `subscription_email_subject`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `waitinglist_email_subject` varchar(255) DEFAULT NULL AFTER `subscription_email_body`;
+
+ALTER TABLE `#__balancirk_lessons`
+    ADD COLUMN IF NOT EXISTS `waitinglist_email_body` text DEFAULT NULL AFTER `waitinglist_email_subject`;
+
+CREATE OR REPLACE VIEW `#__balancirk_lessons_complete` AS
+SELECT a.`id`,
+    a.`name`,
+    b.`name` AS `type`,
+    a.`fee`,
+    a.`year`,
+    a.`start`,
+    a.`end`,
+    a.`start_registration`,
+    a.`end_registration`,
+    a.`state`,
+    a.`lesdays`,
+    a.`max_students`,
+    a.`min_age`,
+    a.`max_age`,
+    (
+        SELECT COUNT(*)
+        FROM `#__balancirk_subscriptions`
+        WHERE `lesson` = a.`id`
+            AND `subscribed` = 0
+    ) AS `numberOfStudents`,
+    (
+        SELECT COUNT(*)
+        FROM `#__balancirk_subscriptions`
+        WHERE `lesson` = a.`id`
+            AND `subscribed` = 1
+    ) AS `numberOnWaitingList`
+FROM `#__balancirk_lessons` a
+    INNER JOIN `#__balancirk_types` b ON a.`type` = b.`id`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Probleem

Na upgrade van versie 1.2.9 naar de laatste versie verschijnt de fout:

```
1054 - Unknown column 'a.min_age' in 'SELECT'
```

## Oorzaak

De `ALTER TABLE` in `1.2.12.sql` combineerde meerdere `ADD COLUMN` clausules in één statement, waarbij latere clausules `AFTER` gebruikten om te verwijzen naar kolommen die eerder in **hetzelfde** statement werden toegevoegd:

```sql
ALTER TABLE `#__balancirk_lessons`
ADD COLUMN `min_age` int(11) DEFAULT NULL AFTER `max_students`,
    ADD COLUMN `max_age` int(11) DEFAULT NULL AFTER `min_age`;  -- ← min_age bestaat hier nog niet
```

Op bepaalde MariaDB/MySQL versies faalt dit omdat `AFTER` een reeds bestaande kolom vereist. Hetzelfde patroon zit in `1.2.20.sql`.

## Fix

1. **`1.2.12.sql`** — Elke `ADD COLUMN` in een apart `ALTER TABLE` statement gezet.
2. **`1.2.20.sql`** — Idem, 4 kolommen elk in een apart statement.
3. **`1.3.2.sql`** (nieuw) — Repair script met `ADD COLUMN IF NOT EXISTS` voor sites die de upgrade al doorlopen hebben met het kapotte script. Herstelt alle potentieel ontbrekende kolommen en hercreëert de view.

## Directe fix voor je huidige site

Voer deze SQL uit op je database (vervang `#__` door je tabel-prefix):

```sql
ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `min_age` int(11) DEFAULT NULL AFTER `max_students`;

ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `max_age` int(11) DEFAULT NULL AFTER `min_age`;

ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `subscription_email_subject` varchar(255) DEFAULT NULL AFTER `max_age`;

ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `subscription_email_body` text DEFAULT NULL AFTER `subscription_email_subject`;

ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `waitinglist_email_subject` varchar(255) DEFAULT NULL AFTER `subscription_email_body`;

ALTER TABLE `#__balancirk_lessons`
    ADD COLUMN IF NOT EXISTS `waitinglist_email_body` text DEFAULT NULL AFTER `waitinglist_email_subject`;
```

Na het mergen van deze PR en herinstallatie van het package via Joomla's extension manager zal het `1.3.2.sql` repair script automatisch draaien.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38065ac4-1dd9-4928-aba3-b7b21a90a234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38065ac4-1dd9-4928-aba3-b7b21a90a234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

