### PR TITLE
Include lesson end date in attendance dates

### DIFF
--- a/components/com_balancirk/site/src/Model/LessonModel.php
+++ b/components/com_balancirk/site/src/Model/LessonModel.php
@@ -329,7 +329,8 @@ class LessonModel extends AdminModel
      */
     public static function getDates($start, $end, $lesday)
     {
-        $period = new DatePeriod(new DateTime($start), new DateInterval('P1D'), new DateTime($end));
+        $endDate = (new DateTime($end))->modify('+1 day');
+        $period = new DatePeriod(new DateTime($start), new DateInterval('P1D'), $endDate);
         $dates = array();
 
         foreach ($period as $date) {

--- a/tests/Unit/Site/Model/LessonModelTest.php
+++ b/tests/Unit/Site/Model/LessonModelTest.php
@@ -8,45 +8,41 @@
  * @license     GNU General Public License version 3.
  */
 
-namespace Joomla\CMS\MVC\Model {
-    if (!class_exists(AdminModel::class)) {
-        class AdminModel
-        {
-        }
-    }
+namespace CoCoCo\Component\Balancirk\Tests\Unit\Site\Model;
+
+use CoCoCo\Component\Balancirk\Site\Model\LessonModel;
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(\Joomla\CMS\MVC\Model\AdminModel::class)) {
+    class_alias(\stdClass::class, \Joomla\CMS\MVC\Model\AdminModel::class);
 }
 
-namespace CoCoCo\Component\Balancirk\Tests\Unit\Site\Model {
-    use CoCoCo\Component\Balancirk\Site\Model\LessonModel;
-    use PHPUnit\Framework\TestCase;
-
-    /**
-     * Test class for lesson date helpers.
-     *
-     * @since  1.3.1
-     */
-    class LessonModelTest extends TestCase
+/**
+ * Test class for lesson date helpers.
+ *
+ * @since  1.3.1
+ */
+class LessonModelTest extends TestCase
+{
+    public function testGetDatesIncludesLessonEndDateWhenItIsALessonDay(): void
     {
-        public function testGetDatesIncludesLessonEndDateWhenItIsALessonDay(): void
-        {
-            $dates = LessonModel::getDates(
-                '2026-05-01',
-                '2026-05-08',
-                [
-                    'Monday' => 0,
-                    'Tuesday' => 0,
-                    'Wednesday' => 0,
-                    'Thursday' => 0,
-                    'Friday' => 1,
-                    'Saturday' => 0,
-                    'Sunday' => 0,
-                ]
-            );
+        $dates = LessonModel::getDates(
+            '2026-05-01',
+            '2026-05-08',
+            [
+                'Monday' => 0,
+                'Tuesday' => 0,
+                'Wednesday' => 0,
+                'Thursday' => 0,
+                'Friday' => 1,
+                'Saturday' => 0,
+                'Sunday' => 0,
+            ]
+        );
 
-            $this->assertSame(
-                ['2026-05-01', '2026-05-08'],
-                array_map(static fn(\DateTimeInterface $date): string => $date->format('Y-m-d'), $dates)
-            );
-        }
+        $this->assertSame(
+            ['2026-05-01', '2026-05-08'],
+            array_map(static fn(\DateTimeInterface $date): string => $date->format('Y-m-d'), $dates)
+        );
     }
 }

--- a/tests/Unit/Site/Model/LessonModelTest.php
+++ b/tests/Unit/Site/Model/LessonModelTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @package     Balancirk.UnitTest
+ * @subpackage  Site
+ *
+ * @copyright   Copyright (C) 2022 CoCoCo. All rights reserved.
+ * @license     GNU General Public License version 3.
+ */
+
+namespace Joomla\CMS\MVC\Model {
+    if (!class_exists(AdminModel::class)) {
+        class AdminModel
+        {
+        }
+    }
+}
+
+namespace CoCoCo\Component\Balancirk\Tests\Unit\Site\Model {
+    use CoCoCo\Component\Balancirk\Site\Model\LessonModel;
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * Test class for lesson date helpers.
+     *
+     * @since  1.3.1
+     */
+    class LessonModelTest extends TestCase
+    {
+        public function testGetDatesIncludesLessonEndDateWhenItIsALessonDay(): void
+        {
+            $dates = LessonModel::getDates(
+                '2026-05-01',
+                '2026-05-08',
+                [
+                    'Monday' => 0,
+                    'Tuesday' => 0,
+                    'Wednesday' => 0,
+                    'Thursday' => 0,
+                    'Friday' => 1,
+                    'Saturday' => 0,
+                    'Sunday' => 0,
+                ]
+            );
+
+            $this->assertSame(
+                ['2026-05-01', '2026-05-08'],
+                array_map(static fn(\DateTimeInterface $date): string => $date->format('Y-m-d'), $dates)
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make lesson date generation include the configured end date so attendance can be recorded on the final lesson day.
- Add a targeted unit test for a lesson that occurs on the configured end date.

### Testing
- Passed: `./vendor/bin/phpunit tests/Unit/Site/Model/LessonModelTest.php`
- Passed: `./vendor/bin/phpunit tests/Unit`
- Passed: `php -l components/com_balancirk/site/src/Model/LessonModel.php && php -l tests/Unit/Site/Model/LessonModelTest.php`
- Passed: `mkdir -p packages && make -B`
- Failing pre-existing: `./vendor/bin/phpcs --standard=PSR12 components/ plugins/ libraries/` reports repository-wide PSR-12 violations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bac325b-51c5-4f2e-b069-1b7f204aa0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bac325b-51c5-4f2e-b069-1b7f204aa0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

