### PR TITLE
Release 1.3.6 - jaar-gebaseerde leeftijdsbeperking voor lessen

### DIFF
--- a/components/com_balancirk/site/src/Helper/LessonAgeHelper.php
+++ b/components/com_balancirk/site/src/Helper/LessonAgeHelper.php
@@ -42,7 +42,7 @@ class LessonAgeHelper
         }
 
         $referenceDate = (string) ($lesson->start ?? '');
-        $age = self::getAgeOnDate($birthdate, $referenceDate);
+        $age = self::getAgeInYear($birthdate, $referenceDate);
 
         if ($age === null) {
             return false;
@@ -60,16 +60,20 @@ class LessonAgeHelper
     }
 
     /**
-     * Calculate age on a specific reference date.
+     * Calculate the age a student reaches during the reference calendar year.
+     *
+     * The age restriction is year based (not date based): everyone who turns
+     * the configured age during the calendar year of the lesson qualifies.
+     * This matches the way school grades ("leerjaren") are grouped.
      *
      * @param   string|null  $birthdate      Student birthdate.
      * @param   string|null  $referenceDate  Reference date.
      *
      * @return  int|null
      *
-     * @since   1.2.12
+     * @since   1.3.6
      */
-    public static function getAgeOnDate(?string $birthdate, ?string $referenceDate): ?int
+    public static function getAgeInYear(?string $birthdate, ?string $referenceDate): ?int
     {
         if (empty($birthdate)) {
             return null;
@@ -82,7 +86,7 @@ class LessonAgeHelper
             return null;
         }
 
-        return $birthDateObject->diff($referenceDateObject)->y;
+        return (int) $referenceDateObject->format('Y') - (int) $birthDateObject->format('Y');
     }
 
     /**

--- a/tests/Unit/Site/Helper/LessonAgeHelperTest.php
+++ b/tests/Unit/Site/Helper/LessonAgeHelperTest.php
@@ -20,11 +20,12 @@ use CoCoCo\Component\Balancirk\Site\Helper\LessonAgeHelper;
  */
 class LessonAgeHelperTest extends TestCase
 {
-    public function testGetAgeOnLessonStartDate(): void
+    public function testGetAgeInYearUsesCalendarYearDifference(): void
     {
-        $age = LessonAgeHelper::getAgeOnDate('2015-09-02', '2025-09-01');
+        // Turns 10 during 2025 even though the birthday falls after the lesson start.
+        $age = LessonAgeHelper::getAgeInYear('2015-09-02', '2025-09-01');
 
-        $this->assertSame(9, $age);
+        $this->assertSame(10, $age);
     }
 
     public function testMatchesLessonReturnsTrueWithinConfiguredRange(): void
@@ -38,15 +39,28 @@ class LessonAgeHelperTest extends TestCase
         $this->assertTrue(LessonAgeHelper::matchesLesson('2015-08-20', $lesson));
     }
 
-    public function testMatchesLessonReturnsFalseBelowMinimumAge(): void
+    public function testMatchesLessonIncludesStudentReachingMinimumAgeLaterInYear(): void
     {
+        // Born late in 2016, turns 9 during 2025: should qualify for a 9+ lesson.
         $lesson = (object) [
             'start' => '2025-09-01',
-            'min_age' => 10,
-            'max_age' => 12,
+            'min_age' => 9,
+            'max_age' => 11,
         ];
 
-        $this->assertFalse(LessonAgeHelper::matchesLesson('2016-10-10', $lesson));
+        $this->assertTrue(LessonAgeHelper::matchesLesson('2016-10-10', $lesson));
+    }
+
+    public function testMatchesLessonReturnsFalseBelowMinimumAge(): void
+    {
+        // Born in 2017, turns only 8 during 2025: below the 9+ minimum.
+        $lesson = (object) [
+            'start' => '2025-09-01',
+            'min_age' => 9,
+            'max_age' => 11,
+        ];
+
+        $this->assertFalse(LessonAgeHelper::matchesLesson('2017-01-05', $lesson));
     }
 
     public function testMatchesLessonReturnsFalseAboveMaximumAge(): void
@@ -57,7 +71,7 @@ class LessonAgeHelperTest extends TestCase
             'max_age' => 8,
         ];
 
-        $this->assertFalse(LessonAgeHelper::matchesLesson('2015-01-01', $lesson));
+        $this->assertFalse(LessonAgeHelper::matchesLesson('2015-12-31', $lesson));
     }
 
     public function testMatchesLessonReturnsTrueWithoutAgeRestrictions(): void
@@ -82,10 +96,10 @@ class LessonAgeHelperTest extends TestCase
         $this->assertFalse(LessonAgeHelper::matchesLesson(null, $lesson));
     }
 
-    public function testGetAgeOnDateReturnsNullForInvalidDates(): void
+    public function testGetAgeInYearReturnsNullForInvalidDates(): void
     {
-        $this->assertNull(LessonAgeHelper::getAgeOnDate('not-a-date', '2025-09-01'));
-        $this->assertNull(LessonAgeHelper::getAgeOnDate('2015-01-01', 'invalid-reference'));
+        $this->assertNull(LessonAgeHelper::getAgeInYear('not-a-date', '2025-09-01'));
+        $this->assertNull(LessonAgeHelper::getAgeInYear('2015-01-01', 'invalid-reference'));
     }
 
     public function testNormalizeNullableIntCastsAndHandlesEmptyValues(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Wat

1. **Functionele wijziging:** de leeftijdsbeperking voor lessen (`min_age` / `max_age`) is nu **jaar-gebaseerd** in plaats van datum-gebaseerd. De leeftijd wordt berekend als `jaar(lesstart) - geboortejaar`, dus iedereen die tijdens het kalenderjaar van de les de vereiste leeftijd bereikt mag inschrijven. Een les met `min_age` 9 / `max_age` 11 laat zo precies het 4de, 5de en 6de leerjaar toe.
2. **Release 1.3.6:** versie opgehoogd in `pkg_balancirk.xml` en de component-manifest, plus een nieuwe update-server-entry en changelog-entry voor automatische updates via Joomla.

## Wijzigingen

- `LessonAgeHelper::getAgeOnDate()` → `getAgeInYear()` met kalenderjaar-berekening; gebruikt door `matchesLesson()` (lessenlijst + inschrijvingsvalidatie, site én admin).
- Unit tests bijgewerkt naar de jaar-gebaseerde semantiek.
- Versie 1.3.5 → 1.3.6 in `pkg_balancirk.xml` en `components/com_balancirk/balancirk.xml`.
- Nieuwe `<update>`-entry (1.3.6, met `sha256`) in `balancirk_update.xml`.
- Nieuwe changelog-entry (1.3.6) in `balancirk_changelog.xml`.

## Nog handmatig te doen om de update live te zetten

De gebouwde package `pkg_balancirk.zip` (versie 1.3.6, sha256 `043634048157608ddd3700813bc471d9aeccae1d36ff1c90f26f8da11e93e636`) is een artifact bij deze run.

1. Maak op GitHub een **release met tag `1.3.6`** in `kriscox/Joomla-extension-balancirk` en upload daar die exacte `pkg_balancirk.zip` als asset (de download-URL in de update-XML wijst hiernaar).
2. **Belangrijk:** de geinstalleerde extensie leest de update-lijst van `kriscox/Joomla-extension-test/.../balancirk_update.xml` (zie `<updateservers>` in `pkg_balancirk.xml`), niet van deze repo. Voeg daar dezelfde 1.3.6-entry toe, anders ziet Joomla de update niet.

## Testen

- `phpunit --testsuite Unit --filter LessonAgeHelper` → 9 tests, allemaal geslaagd.
- Package gebouwd met `make -B pkg_balancirk.zip`; manifest in de zip = 1.3.6; fix aanwezig in de component-zip; alle XML-bestanden valideren.
- Docker is niet beschikbaar in deze omgeving, dus een volledige Joomla-installatietest kon niet draaien; de package-structuur en manifests zijn wel geverifieerd.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

