### PR TITLE
Release 1.3.6 - jaar-gebaseerde leeftijdsbeperking voor lessen

### DIFF
--- a/balancirk_changelog.xml
+++ b/balancirk_changelog.xml
@@ -56,4 +56,12 @@
 			<item>Added to lessons search for lessons in the past years</item>
 		</fix>
 	</changelog>
+	<changelog>
+		<element>com_balancirk</element>
+		<type>package</type>
+		<version>1.3.6</version>
+		<change>
+			<item>Lesson age restrictions are now year based instead of date based: a min_age/max_age lesson admits everyone who reaches that age during the calendar year of the lesson (matching school grades / leerjaren).</item>
+		</change>
+	</changelog>
 </changelogs>

--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -130,4 +130,23 @@
 			version="(4|5|6)\." />
 		<php_minimum>8.1</php_minimum>
 	</update>
+	<update>
+		<name>com_balancirk</name>
+		<description>This is the balancirk plugin</description>
+		<element>com_balancirk</element>
+		<type>package</type>
+		<version>1.3.6</version>
+		<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
+		<infourl title="agosms">https://github.com/kriscox/Joomla-extension-balancirk/blob/master/README.md</infourl>
+		<downloads>
+			<downloadurl type="full"
+				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.6/pkg_balancirk.zip</downloadurl>
+		</downloads>
+		<sha256>043634048157608ddd3700813bc471d9aeccae1d36ff1c90f26f8da11e93e636</sha256>
+		<maintainer>CoCoCo</maintainer>
+		<maintainerurl>http://www.cococo.be</maintainerurl>
+		<targetplatform name="joomla"
+			version="(4|5|6)\." />
+		<php_minimum>8.1</php_minimum>
+	</update>
 </updates>

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -9,7 +9,7 @@
 	<authorUrl>https://cococo.be</authorUrl>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.5</version>
+	<version>1.3.6</version>
 	<description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- This is the PHP namespace under which the extension's

--- a/components/com_balancirk/site/src/Helper/LessonAgeHelper.php
+++ b/components/com_balancirk/site/src/Helper/LessonAgeHelper.php
@@ -42,7 +42,7 @@ class LessonAgeHelper
         }
 
         $referenceDate = (string) ($lesson->start ?? '');
-        $age = self::getAgeOnDate($birthdate, $referenceDate);
+        $age = self::getAgeInYear($birthdate, $referenceDate);
 
         if ($age === null) {
             return false;
@@ -60,16 +60,20 @@ class LessonAgeHelper
     }
 
     /**
-     * Calculate age on a specific reference date.
+     * Calculate the age a student reaches during the reference calendar year.
+     *
+     * The age restriction is year based (not date based): everyone who turns
+     * the configured age during the calendar year of the lesson qualifies.
+     * This matches the way school grades ("leerjaren") are grouped.
      *
      * @param   string|null  $birthdate      Student birthdate.
      * @param   string|null  $referenceDate  Reference date.
      *
      * @return  int|null
      *
-     * @since   1.2.12
+     * @since   1.3.6
      */
-    public static function getAgeOnDate(?string $birthdate, ?string $referenceDate): ?int
+    public static function getAgeInYear(?string $birthdate, ?string $referenceDate): ?int
     {
         if (empty($birthdate)) {
             return null;
@@ -82,7 +86,7 @@ class LessonAgeHelper
             return null;
         }
 
-        return $birthDateObject->diff($referenceDateObject)->y;
+        return (int) $referenceDateObject->format('Y') - (int) $birthDateObject->format('Y');
     }
 
     /**

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.5</version>
+	<version>1.3.6</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->

--- a/tests/Unit/Site/Helper/LessonAgeHelperTest.php
+++ b/tests/Unit/Site/Helper/LessonAgeHelperTest.php
@@ -20,11 +20,12 @@ use CoCoCo\Component\Balancirk\Site\Helper\LessonAgeHelper;
  */
 class LessonAgeHelperTest extends TestCase
 {
-    public function testGetAgeOnLessonStartDate(): void
+    public function testGetAgeInYearUsesCalendarYearDifference(): void
     {
-        $age = LessonAgeHelper::getAgeOnDate('2015-09-02', '2025-09-01');
+        // Turns 10 during 2025 even though the birthday falls after the lesson start.
+        $age = LessonAgeHelper::getAgeInYear('2015-09-02', '2025-09-01');
 
-        $this->assertSame(9, $age);
+        $this->assertSame(10, $age);
     }
 
     public function testMatchesLessonReturnsTrueWithinConfiguredRange(): void
@@ -38,15 +39,28 @@ class LessonAgeHelperTest extends TestCase
         $this->assertTrue(LessonAgeHelper::matchesLesson('2015-08-20', $lesson));
     }
 
-    public function testMatchesLessonReturnsFalseBelowMinimumAge(): void
+    public function testMatchesLessonIncludesStudentReachingMinimumAgeLaterInYear(): void
     {
+        // Born late in 2016, turns 9 during 2025: should qualify for a 9+ lesson.
         $lesson = (object) [
             'start' => '2025-09-01',
-            'min_age' => 10,
-            'max_age' => 12,
+            'min_age' => 9,
+            'max_age' => 11,
         ];
 
-        $this->assertFalse(LessonAgeHelper::matchesLesson('2016-10-10', $lesson));
+        $this->assertTrue(LessonAgeHelper::matchesLesson('2016-10-10', $lesson));
+    }
+
+    public function testMatchesLessonReturnsFalseBelowMinimumAge(): void
+    {
+        // Born in 2017, turns only 8 during 2025: below the 9+ minimum.
+        $lesson = (object) [
+            'start' => '2025-09-01',
+            'min_age' => 9,
+            'max_age' => 11,
+        ];
+
+        $this->assertFalse(LessonAgeHelper::matchesLesson('2017-01-05', $lesson));
     }
 
     public function testMatchesLessonReturnsFalseAboveMaximumAge(): void
@@ -57,7 +71,7 @@ class LessonAgeHelperTest extends TestCase
             'max_age' => 8,
         ];
 
-        $this->assertFalse(LessonAgeHelper::matchesLesson('2015-01-01', $lesson));
+        $this->assertFalse(LessonAgeHelper::matchesLesson('2015-12-31', $lesson));
     }
 
     public function testMatchesLessonReturnsTrueWithoutAgeRestrictions(): void
@@ -82,10 +96,10 @@ class LessonAgeHelperTest extends TestCase
         $this->assertFalse(LessonAgeHelper::matchesLesson(null, $lesson));
     }
 
-    public function testGetAgeOnDateReturnsNullForInvalidDates(): void
+    public function testGetAgeInYearReturnsNullForInvalidDates(): void
     {
-        $this->assertNull(LessonAgeHelper::getAgeOnDate('not-a-date', '2025-09-01'));
-        $this->assertNull(LessonAgeHelper::getAgeOnDate('2015-01-01', 'invalid-reference'));
+        $this->assertNull(LessonAgeHelper::getAgeInYear('not-a-date', '2025-09-01'));
+        $this->assertNull(LessonAgeHelper::getAgeInYear('2015-01-01', 'invalid-reference'));
     }
 
     public function testNormalizeNullableIntCastsAndHandlesEmptyValues(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Wat

1. **Functionele wijziging:** de leeftijdsbeperking voor lessen (`min_age` / `max_age`) is nu **jaar-gebaseerd** in plaats van datum-gebaseerd. De leeftijd wordt berekend als `jaar(lesstart) - geboortejaar`, dus iedereen die tijdens het kalenderjaar van de les de vereiste leeftijd bereikt mag inschrijven. Een les met `min_age` 9 / `max_age` 11 laat zo precies het 4de, 5de en 6de leerjaar toe.
2. **Release 1.3.6:** versie opgehoogd, update-server-entry + changelog-entry toegevoegd.
3. **Automatische release-build:** GitHub Actions workflow die bij een versie-tag `pkg_balancirk.zip` bouwt en als release-asset publiceert.
4. **Update-server-URL gecorrigeerd:** de manifests verwezen naar de niet-bestaande repo `Joomla-extension-test`; nu wijzen ze naar deze repo (`Joomla-extension-balancirk`).

> Vervangt de per ongeluk gesloten PR #31 (zelfde functionele commits).

## Wijzigingen

- `LessonAgeHelper::getAgeOnDate()` → `getAgeInYear()` met kalenderjaar-berekening; gebruikt door `matchesLesson()` (lessenlijst + inschrijvingsvalidatie, site én admin).
- Unit tests bijgewerkt naar de jaar-gebaseerde semantiek.
- Versie 1.3.5 → 1.3.6 in `pkg_balancirk.xml` en `components/com_balancirk/balancirk.xml`.
- Nieuwe `<update>`-entry (1.3.6) in `balancirk_update.xml` en changelog-entry in `balancirk_changelog.xml`.
- Nieuwe workflow `.github/workflows/release.yml` (bouwt + publiceert release op tag-push).
- `changelogurl` + `<updateservers>` in `pkg_balancirk.xml`, `balancirk.xml` en `components/com_balancirk/balancirk.xml` omgezet van `Joomla-extension-test` naar `Joomla-extension-balancirk`.

## Release maken

1. Merge deze PR naar `master`.
2. Maak een release/tag `1.3.6` op GitHub. De workflow bouwt `pkg_balancirk.zip` en hangt die automatisch aan de release.
3. De update-XML staat al in deze repo, dus na de release ziet Joomla de update — let op: bestaande installaties hebben de oude (dode) update-URL nog ingebakken; zie onder.

## Belangrijk voor bestaande installaties

De update-site-URL wordt door Joomla pas bijgewerkt bij een (her)installatie. Een site die nu de oude `Joomla-extension-test`-URL heeft, moet of de update-site-URL handmatig aanpassen (Extensies → Updates → Updatesites), of 1.3.6 eenmalig handmatig installeren via de release-zip. Daarna werkt auto-update voor toekomstige versies.

## Testen

- `phpunit --testsuite Unit --filter LessonAgeHelper` → 9 tests geslaagd.
- CI-buildstappen lokaal gesimuleerd vanaf schone staat (`mkdir packages` + `make pkg_balancirk.zip`): zip bevat manifestversie 1.3.6 en de fix.
- Workflow-YAML + alle XML-manifests valideren; geen verwijzingen naar `Joomla-extension-test` meer.
- Docker niet beschikbaar, dus geen volledige Joomla-installatietest; package-structuur wel geverifieerd.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

