### PR TITLE
Release workflow + correcte update-URLs (fix 1.3.6 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y zip make
+
+      - name: Build installable package
+        run: |
+          mkdir -p packages
+          make pkg_balancirk.zip
+
+      - name: Verify package version matches tag
+        run: |
+          manifest_version=$(sed -n 's#.*<version>\(.*\)</version>.*#\1#p' pkg_balancirk.xml | head -n 1)
+          if [ "$manifest_version" != "${GITHUB_REF_NAME}" ]; then
+            echo "Manifest version ($manifest_version) does not match tag (${GITHUB_REF_NAME})." >&2
+            exit 1
+          fi
+
+      - name: Create or update GitHub release with package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" pkg_balancirk.zip --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" pkg_balancirk.zip \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "Automated release for ${GITHUB_REF_NAME}. See balancirk_changelog.xml for details."
+          fi

--- a/balancirk.xml
+++ b/balancirk.xml
@@ -20,10 +20,10 @@
 			id="pkg_balancirk">pkg_balancirk.zip</file>
 	</files>
 
-	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
 
 	<updateservers>
 		<server type="extension"
-			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_update.xml</server>
+			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_update.xml</server>
 	</updateservers>
 </extension>

--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -142,7 +142,6 @@
 			<downloadurl type="full"
 				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.6/pkg_balancirk.zip</downloadurl>
 		</downloads>
-		<sha256>043634048157608ddd3700813bc471d9aeccae1d36ff1c90f26f8da11e93e636</sha256>
 		<maintainer>CoCoCo</maintainer>
 		<maintainerurl>http://www.cococo.be</maintainerurl>
 		<targetplatform name="joomla"

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -158,11 +158,11 @@
 
 	<scriptfile>script.php</scriptfile>
 
-	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
 
 	<updateservers>
 		<server type="extension"
-			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_update.xml</server>
+			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_update.xml</server>
 	</updateservers>
 
 </extension>

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -30,10 +30,10 @@
 		<language tag="en-GB">en-GB/pkg_balancirk.sys.ini</language>
 	</languages>
 
-	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
 
 	<updateservers>
 		<server type="extension"
-			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-test/master/balancirk_update.xml</server>
+			name="Balancirk">https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_update.xml</server>
 	</updateservers>
 </extension>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Waarom

De 1.3.6-release had geen gebouwde package als asset, waardoor een upload-install van de "Source code (zip)" faalt met *"Install path does not exist"* (de repo-source bevat geen `packages/com_balancirk.zip`). De release-workflow die dit automatisch bouwt zat nog niet op `master`, en de update-URLs wezen nog naar de niet-bestaande repo `Joomla-extension-test`.

## Wijzigingen

- **`.github/workflows/release.yml`**: bouwt bij het pushen van een versie-tag (bv. `1.3.6`) `pkg_balancirk.zip` en koppelt die aan de GitHub-release (maakt de release aan, of upload de asset als de release al bestaat). Verifieert ook dat de manifestversie gelijk is aan de tag.
- **Update-URLs gecorrigeerd**: `changelogurl` + `<updateservers>` in `pkg_balancirk.xml`, `balancirk.xml` en `components/com_balancirk/balancirk.xml` wijzen nu naar `Joomla-extension-balancirk`.
- **`sha256` verwijderd** uit de 1.3.6 update-entry (de door CI gebouwde zip heeft een andere hash; consistent met de 1.3.0-entry).

## Vervolgstappen (na merge)

1. Verwijder de bestaande release **én** tag `1.3.6` (de tag wijst nu naar een commit zonder workflow).
2. Maak release/tag `1.3.6` opnieuw aan op `master`. De workflow bouwt en koppelt `pkg_balancirk.zip` automatisch.
3. Installeer/Update met die asset.

## Testen

- Workflow-YAML valideert; alle XML-manifests valideren; geen `Joomla-extension-test`-verwijzingen meer.
- CI-buildstappen lokaal gesimuleerd (`mkdir packages` + `make pkg_balancirk.zip`): geldige package, versie 1.3.6, fix aanwezig.
- Bevestigd dat de werkende 1.2.9-release exact dezelfde pakketstructuur heeft als de `make`-build, dus de gebouwde 1.3.6-package is installeerbaar.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

