### PR TITLE
Release 1.3.7 - fix update-fout + fatale fout bij inschrijven leerling

### DIFF
--- a/balancirk_changelog.xml
+++ b/balancirk_changelog.xml
@@ -70,6 +70,7 @@
 		<version>1.3.7</version>
 		<fix>
 			<item>Fixed "Duplicate column name" error that could abort the update: the 1.3.2 repair script no longer re-adds columns that 1.2.12.sql and 1.2.20.sql already create.</item>
+			<item>Fixed a fatal TypeError ("Argument #1 ($value) must be of type object|array, false given") when registering a new student: the student form no longer passes a denied/empty record to the data preparation event.</item>
 		</fix>
 	</changelog>
 </changelogs>

--- a/balancirk_changelog.xml
+++ b/balancirk_changelog.xml
@@ -64,4 +64,12 @@
 			<item>Lesson age restrictions are now year based instead of date based: a min_age/max_age lesson admits everyone who reaches that age during the calendar year of the lesson (matching school grades / leerjaren).</item>
 		</change>
 	</changelog>
+	<changelog>
+		<element>com_balancirk</element>
+		<type>package</type>
+		<version>1.3.7</version>
+		<fix>
+			<item>Fixed "Duplicate column name" error that could abort the update: the 1.3.2 repair script no longer re-adds columns that 1.2.12.sql and 1.2.20.sql already create.</item>
+		</fix>
+	</changelog>
 </changelogs>

--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -148,4 +148,22 @@
 			version="(4|5|6)\." />
 		<php_minimum>8.1</php_minimum>
 	</update>
+	<update>
+		<name>com_balancirk</name>
+		<description>This is the balancirk plugin</description>
+		<element>com_balancirk</element>
+		<type>package</type>
+		<version>1.3.7</version>
+		<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
+		<infourl title="agosms">https://github.com/kriscox/Joomla-extension-balancirk/blob/master/README.md</infourl>
+		<downloads>
+			<downloadurl type="full"
+				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.7/pkg_balancirk.zip</downloadurl>
+		</downloads>
+		<maintainer>CoCoCo</maintainer>
+		<maintainerurl>http://www.cococo.be</maintainerurl>
+		<targetplatform name="joomla"
+			version="(4|5|6)\." />
+		<php_minimum>8.1</php_minimum>
+	</update>
 </updates>

--- a/components/com_balancirk/admin/sql/updates/mysql/1.3.2.sql
+++ b/components/com_balancirk/admin/sql/updates/mysql/1.3.2.sql
@@ -1,33 +1,12 @@
 /**************************************************************************************************
  *                                                                                                 *
- *  Repair script: ensure min_age/max_age and email template columns exist on lessons table.       *
+ *  Recreate the lessons_complete view.                                                            *
  *                                                                                                 *
- *  Each column is added in a separate ALTER TABLE statement so that a "Duplicate column"          *
- *  error on an already-upgraded site does not prevent the remaining columns from being added.     *
- *                                                                                                 *
- *  Note: ADD COLUMN IF NOT EXISTS is NOT used because it is unsupported on MySQL < 8.0.3.        *
- *  Joomla's schema updater logs and skips individual statement errors, so duplicate-column        *
- *  errors are harmless here.                                                                      *
+ *  The min_age/max_age and email template columns are created once by 1.2.12.sql and 1.2.20.sql.  *
+ *  They are no longer re-added here: re-adding existing columns aborted the update with a          *
+ *  "Duplicate column" error. This script now only (re)creates the view.                           *
  *                                                                                                 *
  **************************************************************************************************/
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `min_age` int(11) DEFAULT NULL AFTER `max_students`;
-
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `max_age` int(11) DEFAULT NULL AFTER `min_age`;
-
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `subscription_email_subject` varchar(255) DEFAULT NULL AFTER `max_age`;
-
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `subscription_email_body` text DEFAULT NULL AFTER `subscription_email_subject`;
-
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `waitinglist_email_subject` varchar(255) DEFAULT NULL AFTER `subscription_email_body`;
-
-ALTER TABLE `#__balancirk_lessons`
-    ADD COLUMN `waitinglist_email_body` text DEFAULT NULL AFTER `waitinglist_email_subject`;
-
 CREATE OR REPLACE VIEW `#__balancirk_lessons_complete` AS
 SELECT a.`id`,
     a.`name`,

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -9,7 +9,7 @@
 	<authorUrl>https://cococo.be</authorUrl>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.6</version>
+	<version>1.3.7</version>
 	<description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- This is the PHP namespace under which the extension's

--- a/components/com_balancirk/site/src/Model/StudentModel.php
+++ b/components/com_balancirk/site/src/Model/StudentModel.php
@@ -95,9 +95,15 @@ class StudentModel extends AdminModel
      */
     public function getItem($pk = null)
     {
-        $canDo = ContentHelper::getActions('com_balancirk');
-        if (!($canDo->get('students.viewall') || $this->isParent($pk))) {
-            return false;
+        $pk = (!empty($pk)) ? $pk : (int) $this->getState('student.id');
+
+        // A new (empty) record is always available; only existing records are access checked.
+        if (!empty($pk)) {
+            $canDo = ContentHelper::getActions('com_balancirk');
+
+            if (!($canDo->get('students.viewall') || $this->isParent($pk))) {
+                return false;
+            }
         }
 
         return parent::getItem($pk);
@@ -191,6 +197,11 @@ class StudentModel extends AdminModel
 
         if (empty($data)) {
             $data = $this->getItem();
+        }
+
+        // getItem() can return false when access is denied; never pass that to preprocessData().
+        if ($data === false) {
+            $data = [];
         }
 
         $this->preprocessData($this->typeAlias, $data);

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.6</version>
+	<version>1.3.7</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Wat zit erin (release 1.3.7)

### 1. Fatale fout bij inschrijven van een nieuwe leerling (urgent)
Bij `view=student&layout=edit&id=0` crashte de site met:
`Joomla\CMS\Event\Model\Prepare... Argument #1 ($value) must be of type object|array, false given`.

Oorzaak: `StudentModel::getItem()` gaf `false` terug voor een **nieuwe** inschrijving (niemand is "ouder" van een nog onbestaande leerling), en `loadFormData()` gaf die `false` door aan `preprocessData()`. Het getypeerde `PrepareDataEvent` in recente Joomla-versies eist `object|array`, dus `false` gaf een fatale TypeError.

Fix in `site/src/Model/StudentModel.php`:
- `getItem()` laat nieuwe (lege `pk`) records altijd toe en doet de toegangscontrole enkel op bestaande records.
- `loadFormData()` geeft nooit `false` door aan `preprocessData()`.

### 2. "Duplicate column name" bij updaten
`1.3.2.sql` voegde kolommen opnieuw toe die `1.2.12.sql`/`1.2.20.sql` al aanmaken. Verwijderd; het script (her)maakt nu enkel de `lessons_complete`-view.

Versie 1.3.6 → 1.3.7, met changelog- en update-server-entry.

## Testen

- **Inschrijf-crash:** geen Joomla-runtime beschikbaar, dus de exacte foutconditie gereproduceerd met een PHP-script: `false` doorgeven aan een `object|array`-parameter geeft exact `Argument #1 ($value) must be of type object|array, false given`; na de guard wordt `[]` doorgegeven en is er geen fout. Code gelint (`php -l` OK, PSR-12 schoon voor de gewijzigde regels).
- **SQL-fix (MariaDB 10.11):** volledige upgrade-keten `1.2.12 → 1.2.20 → 1.3.2 → 1.3.5` draait foutloos; oude `1.3.2.sql` faalde met `ERROR 1060 Duplicate column name 'min_age'`, nieuwe versie niet meer.
- Package gebouwd: versie 1.3.7, beide fixes aanwezig in de component-zip.

## Productie

Je productie staat op 1.3.6. Na merge van deze PR: maak release/tag `1.3.7` aan (workflow bouwt en koppelt `pkg_balancirk.zip` automatisch) en installeer die. De install draait schoon (schema staat al op 1.3.5) en de inschrijf-fout is dan opgelost.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6de8672-70a7-449c-90a5-e0e416cc8c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

