### PR TITLE
Prepare release 1.3.8

### DIFF
--- a/balancirk.xml
+++ b/balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.2.35</version>
+	<version>1.3.8</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->

--- a/balancirk_changelog.xml
+++ b/balancirk_changelog.xml
@@ -73,4 +73,16 @@
 			<item>Fixed a fatal TypeError ("Argument #1 ($value) must be of type object|array, false given") when registering a new student: the student form no longer passes a denied/empty record to the data preparation event.</item>
 		</fix>
 	</changelog>
+	<changelog>
+		<element>pkg_balancirk</element>
+		<type>package</type>
+		<version>1.3.8</version>
+		<fix>
+			<item>Fixed member registration so invalid form data no longer creates Joomla users and validated data is used consistently.</item>
+			<item>Hardened lesson subscriptions with server-side checks for open registration periods, non-trashed lessons, duplicate subscriptions, and clearer API error messages.</item>
+			<item>Fixed student detail status so it is based on actual subscriptions in non-trashed lessons instead of the stored student state.</item>
+			<item>Added a configurable school year offset, defaulting to six months.</item>
+			<item>Fixed Joomla update metadata so package updates match the installed package identity.</item>
+		</fix>
+	</changelog>
 </changelogs>

--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -172,4 +172,23 @@
 			version="(4|5|6)\." />
 		<php_minimum>8.1</php_minimum>
 	</update>
+	<update>
+		<name>Balancirk</name>
+		<description>Balancirk extension package</description>
+		<element>pkg_balancirk</element>
+		<type>package</type>
+		<client>site</client>
+		<version>1.3.8</version>
+		<changelogurl>https://raw.githubusercontent.com/kriscox/Joomla-extension-balancirk/master/balancirk_changelog.xml</changelogurl>
+		<infourl title="agosms">https://github.com/kriscox/Joomla-extension-balancirk/blob/master/README.md</infourl>
+		<downloads>
+			<downloadurl type="full"
+				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.8/pkg_balancirk.zip</downloadurl>
+		</downloads>
+		<maintainer>CoCoCo</maintainer>
+		<maintainerurl>http://www.cococo.be</maintainerurl>
+		<targetplatform name="joomla"
+			version="(4|5|6)\." />
+		<php_minimum>8.1</php_minimum>
+	</update>
 </updates>

--- a/components/com_balancirk/balancirk.xml
+++ b/components/com_balancirk/balancirk.xml
@@ -9,7 +9,7 @@
 	<authorUrl>https://cococo.be</authorUrl>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.7</version>
+	<version>1.3.8</version>
 	<description>COM_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- This is the PHP namespace under which the extension's

--- a/pkg_balancirk.xml
+++ b/pkg_balancirk.xml
@@ -11,7 +11,7 @@
 	<authorEmail>info@cococo.be</authorEmail>
 	<copyright>CoCoCo</copyright>
 	<license>GPL v3</license>
-	<version>1.3.7</version>
+	<version>1.3.8</version>
 	<description>PKG_BALANCIRK_MODULE_DESCRIPTION</description>
 
 	<!-- on update don't forget to add also to makefile -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Bump package/component/wrapper manifest versions to `1.3.8`.
- Add `1.3.8` to `balancirk_update.xml` with package identity `pkg_balancirk`, `type=package`, `client=site`.
- Add `1.3.8` changelog entries for the registration, subscription, student status, school year offset, and update metadata fixes.

### Testing
- `php -r '...simplexml_load_file...'` passes for `balancirk.xml`, `pkg_balancirk.xml`, `components/com_balancirk/balancirk.xml`, `balancirk_update.xml`, and `balancirk_changelog.xml`.
- `php -r '...release metadata...'` confirms package/component version `1.3.8` and an update XML entry for `1.3.8` with `pkg_balancirk` + `client=site`.
- `./vendor/bin/phpunit --testsuite Unit` passes: 46 tests, 66 assertions, 14 skipped.
- `make -B pkg_balancirk.zip` passes.
- `unzip -p pkg_balancirk.zip pkg_balancirk.xml | sed -n '1,20p'` confirms the built package manifest contains `<version>1.3.8</version>`.
- `git diff --check` passes.

### Release steps after merge
1. Merge this PR into `master`.
2. Create and push tag `1.3.8` on the merged master commit.
3. The GitHub Actions release workflow will build and upload `pkg_balancirk.zip` for that tag.
4. In Joomla, clear/update extension update cache and check for updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b44fcbce-425c-4f89-8484-feee4bd5be1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b44fcbce-425c-4f89-8484-feee4bd5be1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

