### PR TITLE
Fix all years subscriptions filter

### DIFF
--- a/components/com_balancirk/site/src/Model/SubscriptionsModel.php
+++ b/components/com_balancirk/site/src/Model/SubscriptionsModel.php
@@ -150,9 +150,7 @@ class SubscriptionsModel extends ListModel
         }
         elseif ($current === '')
         {
-            $trashedState = -2;
-            $query->where($db->quoteName('a.state') . ' <> :trashedState');
-            $query->bind(':trashedState', $trashedState, ParameterType::INTEGER);
+            $query->where('(' . $db->quoteName('a.state') . ' = 0 OR ' . $db->quoteName('a.state') . ' = 1)');
         }
 
         // Filter by selected year

--- a/components/com_balancirk/site/src/Model/SubscriptionsModel.php
+++ b/components/com_balancirk/site/src/Model/SubscriptionsModel.php
@@ -12,7 +12,6 @@ namespace CoCoCo\Component\Balancirk\Site\Model;
 
 \defined('_JEXEC') or die;
 
-use CoCoCo\Component\Balancirk\Site\Helper\SchoolYearHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
@@ -151,19 +150,14 @@ class SubscriptionsModel extends ListModel
         }
         elseif ($current === '')
         {
-            $query->where('(' . $db->quoteName('a.state') . ' = 0 OR ' . $db->quoteName('a.state') . ' = 1)');
+            $trashedState = -2;
+            $query->where($db->quoteName('a.state') . ' <> :trashedState');
+            $query->bind(':trashedState', $trashedState, ParameterType::INTEGER);
         }
 
         // Filter by selected year
         $selectedYear = $this->getState('filter.year');
-        $today = date('Y-m-d');
-        if (empty($selectedYear))
-        {
-            $schoolYear = SchoolYearHelper::getCurrentSchoolYear($today);
-            $query->where($db->quote($schoolYear) . ' = `year`');
-            $this->setState('filter.year', $schoolYear);
-        }
-        else
+        if ($selectedYear !== '' && $selectedYear !== null)
         {
             $query->where($db->quoteName('a.year') . ' = ' . $db->quote($selectedYear));
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Keep an empty subscriptions year filter empty so `Alle schooljaren` shows all years instead of switching back to the configured current school year.
- Leave all other subscription filters unchanged, including the existing empty status filter behavior (`state = 0 OR state = 1`).

### Root cause
- `SubscriptionsModel::getListQuery()` treated an empty `filter.year` as "use current school year", added a year `WHERE`, and wrote that year back into model state. The template then selected the current year instead of keeping `Alle schooljaren` selected.

### Testing
- `php -l components/com_balancirk/site/src/Model/SubscriptionsModel.php` passes.
- `./vendor/bin/phpunit --testsuite Unit` passes: 46 tests, 66 assertions, 14 skipped.
- `make -B pkg_balancirk.zip` passes.
- `git diff --check` passes.
- `make container-install` could not run because Docker is not installed in this cloud image.
- `./vendor/bin/phpcs --standard=PSR12 components/com_balancirk/site/src/Model/SubscriptionsModel.php` still fails on existing style debt in that model.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b44fcbce-425c-4f89-8484-feee4bd5be1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b44fcbce-425c-4f89-8484-feee4bd5be1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

