### PR TITLE
docs: SPA git-workflow via Single-page-site-ontwikkeling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Balancirk is a Joomla 4 extension package for managing members, students, lesson
 
 This is NOT a standalone application. It requires installation into a Joomla 4 CMS instance.
 
+## Conventions
+
+- Write **code comments** and **in-repository documentation** (README sections, inline notes in source) in **English**. User-facing Joomla language strings stay in their locale files.
+
 ## Cursor Cloud specific instructions
 
 ### Prerequisites (installed by update script)

--- a/README.md
+++ b/README.md
@@ -86,3 +86,22 @@ make member-spa-deploy
 Na deploy wordt de build geplaatst in `components/com_balancirk/media/member-spa/browser` en kan je in Joomla een menu-item maken naar:
 
 `index.php?option=com_balancirk&view=member&layout=spa`
+
+### Git-workflow (SPA-ontwikkeling)
+
+SPA-wijzigingen lopen via een aparte integratiebranch, niet rechtstreeks naar `master`:
+
+| Branch | Doel |
+|--------|------|
+| `Single-page-site-ontwikkeling` | Integratiebranch voor alle SPA-werk |
+| `cursor/...` of feature branches | Concrete wijzigingen (bijv. `cursor/single-page-site-3637`) |
+| `master` | Productie / Joomla-releases (SPA merge pas wanneer klaar) |
+
+**Stappen:**
+
+1. Branch af van `Single-page-site-ontwikkeling` (niet van `master`).
+2. Open een PR met **base** `Single-page-site-ontwikkeling`.
+3. Na review: merge in `Single-page-site-ontwikkeling`.
+4. Als de SPA-kern stabiel is: aparte PR van `Single-page-site-ontwikkeling` → `master`.
+
+Meer detail over de Angular-app zelf: `frontend/member-spa/README.md`.

--- a/README.md
+++ b/README.md
@@ -87,21 +87,21 @@ Na deploy wordt de build geplaatst in `components/com_balancirk/media/member-spa
 
 `index.php?option=com_balancirk&view=member&layout=spa`
 
-### Git-workflow (SPA-ontwikkeling)
+### Git workflow (SPA development)
 
-SPA-wijzigingen lopen via een aparte integratiebranch, niet rechtstreeks naar `master`:
+SPA changes go through a dedicated integration branch, not directly into `master`:
 
-| Branch | Doel |
-|--------|------|
-| `Single-page-site-ontwikkeling` | Integratiebranch voor alle SPA-werk |
-| `cursor/...` of feature branches | Concrete wijzigingen (bijv. `cursor/single-page-site-3637`) |
-| `master` | Productie / Joomla-releases (SPA merge pas wanneer klaar) |
+| Branch | Purpose |
+|--------|---------|
+| `Single-page-site-ontwikkeling` | Integration branch for all SPA work |
+| `cursor/...` or feature branches | Individual changes (e.g. `cursor/single-page-site-3637`) |
+| `master` | Production / Joomla releases (merge SPA when ready) |
 
-**Stappen:**
+**Steps:**
 
-1. Branch af van `Single-page-site-ontwikkeling` (niet van `master`).
-2. Open een PR met **base** `Single-page-site-ontwikkeling`.
-3. Na review: merge in `Single-page-site-ontwikkeling`.
-4. Als de SPA-kern stabiel is: aparte PR van `Single-page-site-ontwikkeling` → `master`.
+1. Branch from `Single-page-site-ontwikkeling` (not from `master`).
+2. Open a PR with **base** `Single-page-site-ontwikkeling`.
+3. After review, merge into `Single-page-site-ontwikkeling`.
+4. When the SPA core is stable, open a separate PR from `Single-page-site-ontwikkeling` → `master`.
 
-Meer detail over de Angular-app zelf: `frontend/member-spa/README.md`.
+See `frontend/member-spa/README.md` for Angular app details.

--- a/frontend/member-spa/README.md
+++ b/frontend/member-spa/README.md
@@ -1,13 +1,13 @@
 # Balancirk Member SPA (Angular)
 
-Mobile-first one-page ledenmodule voor Balancirk, gebouwd op de bestaande Joomla API backend.
+Mobile-first one-page member area for Balancirk, built on the existing Joomla API backend.
 
-## Doel
+## Goals
 
-- eenvoudig voor niet-technische gebruikers
-- helder op smartphone schermen
-- bruikbaar als PWA (installable op GSM)
-- integreerbaar in Joomla via `layout=spa`
+- Simple for non-technical users
+- Clear on smartphone screens
+- Usable as a PWA (installable on mobile)
+- Integrable in Joomla via `layout=spa`
 
 ## Local development
 
@@ -17,22 +17,22 @@ npm install
 npm start
 ```
 
-Standaard API-base: `/api/index.php/v1/balancirk` (zelfde domain, Joomla sessie/cookies).
+Default API base: `/api/index.php/v1/balancirk` (same domain, Joomla session/cookies).
 
-## Productie build + Joomla deploy
+## Production build + Joomla deploy
 
 ```bash
 cd frontend/member-spa
 npm run build:deploy
 ```
 
-Dit kopieert de build naar:
+This copies the build to:
 
 `components/com_balancirk/media/member-spa/browser`
 
-De Joomla layout `member&layout=spa` laadt daarna automatisch deze bestanden.
+The Joomla layout `member&layout=spa` then loads these files automatically.
 
-## Auth in de app
+## Auth in the app
 
-- Primair: Joomla sessiecookie (`withCredentials`)
-- Optioneel: Bearer token via `localStorage.setItem('balancirk_api_token', '...')`
+- Primary: Joomla session cookie (`withCredentials`)
+- Optional: Bearer token via `localStorage.setItem('balancirk_api_token', '...')`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the SPA branch workflow in the root README and records the English-language convention for agents.

- SPA git workflow section (English): integration via `Single-page-site-ontwikkeling`, then `master` when ready
- `AGENTS.md`: code comments and in-repo documentation must be in English (Joomla language strings unchanged)
- `frontend/member-spa/README.md` translated to English
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ceeac33-0db6-4ae4-bd14-0f1cf6dce72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ceeac33-0db6-4ae4-bd14-0f1cf6dce72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

