### PR TITLE
chore: clean up member forms and local agent branches

### DIFF
--- a/components/com_balancirk/admin/tmpl/member/edit.php
+++ b/components/com_balancirk/admin/tmpl/member/edit.php
@@ -37,7 +37,6 @@ HTMLHelper::_('behavior.keepalive');
 						<?= $this->form->renderField('name'); ?>
 						<?= $this->form->renderField('email'); ?>
 						<?= $this->form->renderField('phone'); ?>
-						<?= $this->form->renderField('birthdate'); ?>
 					</div>
 				</div>
 			</div>

--- a/components/com_balancirk/site/src/Model/MemberModel.php
+++ b/components/com_balancirk/site/src/Model/MemberModel.php
@@ -12,7 +12,6 @@ namespace CoCoCo\Component\Balancirk\Site\Model;
 
 \defined('_JEXEC') or die;
 
-use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
 use Joomla\CMS\Router\Route;

--- a/components/com_balancirk/site/tmpl/member/edit.php
+++ b/components/com_balancirk/site/tmpl/member/edit.php
@@ -66,9 +66,6 @@ HTMLHelper::_('behavior.keepalive');
 			<div class="col-12 col-md-6">
 				<?= $this->form->renderField('phone'); ?>
 			</div>
-			<div class="col-12 col-md-6">
-				<?= $this->form->renderField('birthdate'); ?>
-			</div>
 		</div>
 	</div>
 

--- a/components/com_balancirk/site/tmpl/member/register.php
+++ b/components/com_balancirk/site/tmpl/member/register.php
@@ -76,9 +76,6 @@ HTMLHelper::_('behavior.keepalive');
 			<div class="col-12 col-md-6">
 				<?= $this->form->renderField('phone'); ?>
 			</div>
-			<div class="col-12 col-md-6">
-				<?= $this->form->renderField('birthdate'); ?>
-			</div>
 		</div>
 	</div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Housekeeping after merged agent work (#54, #55):

- Remove `birthdate` render from site member register/edit and admin member edit (field is not defined in `member.xml`; birthdate belongs on students)
- Remove unused `use Exception` import in site `MemberModel`

Agent branches `cursor/*-d84b` were already removed on the remote; local release branch deleted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8201ded-20f6-4519-b5ad-9b64b816d84b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8201ded-20f6-4519-b5ad-9b64b816d84b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

