### PR TITLE
docs: package, test, and release instructions for agents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,14 +85,17 @@ jobs:
           if gh pr view "${branch}" --json number >/dev/null 2>&1; then
             pr_url=$(gh pr view "${branch}" --json url -q .url)
           else
+            checksum="${{ steps.checksum.outputs.sha256 }}"
+            body=$(printf '%s\n' \
+              "Adds <sha256> for release ${version} to balancirk_update.xml so Joomla can validate package integrity." \
+              "" \
+              "Checksum: ${checksum}" \
+              "Generated automatically by the Release workflow.")
             pr_url=$(gh pr create \
               --base master \
               --head "${branch}" \
               --title "chore: add sha256 checksum for ${version}" \
-              --body "Adds \`<sha256>\` for release **${version}** to \`balancirk_update.xml\` so Joomla can validate package integrity.
-
-Checksum: \`${{ steps.checksum.outputs.sha256 }}\`
-Generated automatically by the Release workflow.")
+              --body "${body}")
           fi
 
           gh pr merge "${pr_url}" --squash --delete-branch \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build-and-release:
@@ -14,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y zip make
@@ -31,6 +34,15 @@ jobs:
             exit 1
           fi
 
+      - name: Add sha256 checksum to update feed
+        id: checksum
+        run: |
+          sha256=$(sha256sum pkg_balancirk.zip | cut -d' ' -f1)
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/set-update-checksum.sh
+          ./scripts/set-update-checksum.sh "${GITHUB_REF_NAME}" "${sha256}" balancirk_update.xml
+          echo "Checksum for ${GITHUB_REF_NAME}: ${sha256}"
+
       - name: Create or update GitHub release with package
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,3 +54,47 @@ jobs:
               --title "${GITHUB_REF_NAME}" \
               --notes "Automated release for ${GITHUB_REF_NAME}. See balancirk_changelog.xml for details."
           fi
+
+      - name: Commit checksum to master via squash PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          version="${GITHUB_REF_NAME}"
+          branch="chore/update-checksum-${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- balancirk_update.xml; then
+            echo "balancirk_update.xml already has the expected checksum; nothing to commit."
+            exit 0
+          fi
+
+          # Build a linear commit on top of current master (branch protection: no merge commits).
+          git fetch origin master
+          git stash push -u -m "checksum-${version}" -- balancirk_update.xml
+          git checkout -B "${branch}" origin/master
+          git stash pop
+
+          git add balancirk_update.xml
+          git commit -m "chore: add sha256 checksum for ${version}"
+
+          git push -u origin "${branch}" --force
+
+          if gh pr view "${branch}" --json number >/dev/null 2>&1; then
+            pr_url=$(gh pr view "${branch}" --json url -q .url)
+          else
+            pr_url=$(gh pr create \
+              --base master \
+              --head "${branch}" \
+              --title "chore: add sha256 checksum for ${version}" \
+              --body "Adds \`<sha256>\` for release **${version}** to \`balancirk_update.xml\` so Joomla can validate package integrity.
+
+Checksum: \`${{ steps.checksum.outputs.sha256 }}\`
+Generated automatically by the Release workflow.")
+          fi
+
+          gh pr merge "${pr_url}" --squash --delete-branch \
+            --subject "chore: add sha256 checksum for ${version}" \
+            --body "Automated follow-up from the Release workflow."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,18 +36,7 @@ make -B packages/com_balancirk.zip packages/balancirk.zip pkg_balancirk.zip
 3. Add an English entry to `balancirk_changelog.xml` and a matching block to `balancirk_update.xml`.
 4. Rebuild `pkg_balancirk.zip` (command above). Optionally also build `VERSION.tar.gz` / `VERSION.zip` like previous releases.
 5. Open a PR into `master` (branch is protected: **squash-merge**, no merge commits). After merge, tag `VERSION` on `master` and push the tag — GitHub Actions publishes the release with `pkg_balancirk.zip`.
-6. **Checksum (required to avoid Joomla integrity warning):** after the GitHub release exists, download **that** release asset (Actions rebuilds the zip, so do not hash the local pre-tag zip), then add lowercase hashes to the matching `<update>` block in `balancirk_update.xml`:
-
-```bash
-gh release download VERSION -p pkg_balancirk.zip -D /tmp --clobber
-sha256sum /tmp/pkg_balancirk.zip
-```
-
-```xml
-<sha256>PASTE_HASH_HERE</sha256>
-```
-
-Optional: also `<sha384>` / `<sha512>`. Commit the updated `balancirk_update.xml` to `master` (small follow-up PR). Joomla reads the feed from GitHub raw; without these tags it shows “does not provide a checksum…”.
+6. **Checksum:** the Release workflow hashes the built `pkg_balancirk.zip`, writes `<sha256>` into `balancirk_update.xml`, and opens/squash-merges a follow-up PR to `master`. No manual checksum step is required. Helper script: `scripts/set-update-checksum.sh`.
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,27 @@ The Angular member SPA is developed separately on the `Single-page-site-ontwikke
 ## Conventions
 
 - Write **code comments** and **in-repository documentation** (README sections, inline notes in source) in **English**. User-facing Joomla language strings stay in their locale files.
+- **`balancirk_changelog.xml` entries must be in English.**
+
+## Packages & testing
+
+- For test installs, **only** use root `pkg_balancirk.zip` (never sub-zips alone, never versioned `1.x.y.zip` as the install source).
+- Rebuild without bumping the version:
+
+```bash
+make -B packages/com_balancirk.zip packages/balancirk.zip pkg_balancirk.zip
+```
+
+- Do **not** run `make` / `make all` or `./scripts/version.sh bump` for ordinary fixes or test packages. That bumps the version; version bumps are **release-only** (see below).
+- Joomla `method="upgrade"` does **not** delete files removed from a new zip. If files must disappear on upgrade, add them to `$deleteFiles` / `$deleteFolders` in `components/com_balancirk/script.php` and call `removeFiles()`. Never remove active API files used for presence/attendance (`PresencesController`, routes in `plugins/balancirk/balancirk.php`).
+
+## Releases (master only)
+
+1. Next version = latest **published GitHub release tag** + patch (check `gh release list`; do not trust a higher number already sitting in XML if it was never released).
+2. Set `<version>` in `balancirk.xml`, `pkg_balancirk.xml`, and `components/com_balancirk/balancirk.xml`.
+3. Add an English entry to `balancirk_changelog.xml` and a matching block to `balancirk_update.xml`.
+4. Rebuild `pkg_balancirk.zip` (command above). Optionally also build `VERSION.tar.gz` / `VERSION.zip` like previous releases.
+5. Open a PR into `master` (branch is protected: **squash-merge**, no merge commits). After merge, tag `VERSION` on `master` and push the tag — GitHub Actions publishes the release with `pkg_balancirk.zip`.
 
 ## Cursor Cloud specific instructions
 
@@ -41,20 +62,20 @@ Note: The `composer.json` `cs-check` script targets `src/` which does not exist 
 ### Build
 
 ```bash
-make -B
+make -B packages/com_balancirk.zip packages/balancirk.zip pkg_balancirk.zip
 ```
 
-This forces a full rebuild of the installable Joomla package zip (including sub-packages for the component and plugin). The `-B` flag unconditionally rebuilds all targets.
+Rebuilds the installable Joomla package zip without bumping the version. Use this for test packages.
 
 ### Testing
 
 There are no automated unit/integration tests in this repository. Validation is done via:
 1. `phpcs` linting (PSR-12 standard)
-2. Building the package zip successfully
-3. Installing into a Joomla 4 instance (external)
+2. Building `pkg_balancirk.zip` successfully
+3. Installing **`pkg_balancirk.zip`** into a Joomla 4 test instance (external)
 
 ### Important notes
 
 - The `vendor/` directory is committed to the repo, so `composer install` is fast (no network needed if lock file matches).
 - The `debug` target in `components/com_balancirk/Makefile` deploys to a remote server via SSH — do not use it in cloud environments.
-- Built artifacts (`pkg_balancirk.zip`, `packages/*.zip`) are also committed to the repo; `make` rebuilds them fresh.
+- Built artifacts (`pkg_balancirk.zip`, `packages/*.zip`) are also committed to the repo; rebuild them when shipping a package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,18 @@ make -B packages/com_balancirk.zip packages/balancirk.zip pkg_balancirk.zip
 3. Add an English entry to `balancirk_changelog.xml` and a matching block to `balancirk_update.xml`.
 4. Rebuild `pkg_balancirk.zip` (command above). Optionally also build `VERSION.tar.gz` / `VERSION.zip` like previous releases.
 5. Open a PR into `master` (branch is protected: **squash-merge**, no merge commits). After merge, tag `VERSION` on `master` and push the tag — GitHub Actions publishes the release with `pkg_balancirk.zip`.
+6. **Checksum (required to avoid Joomla integrity warning):** after the GitHub release exists, download **that** release asset (Actions rebuilds the zip, so do not hash the local pre-tag zip), then add lowercase hashes to the matching `<update>` block in `balancirk_update.xml`:
+
+```bash
+gh release download VERSION -p pkg_balancirk.zip -D /tmp --clobber
+sha256sum /tmp/pkg_balancirk.zip
+```
+
+```xml
+<sha256>PASTE_HASH_HERE</sha256>
+```
+
+Optional: also `<sha384>` / `<sha512>`. Commit the updated `balancirk_update.xml` to `master` (small follow-up PR). Joomla reads the feed from GitHub raw; without these tags it shows “does not provide a checksum…”.
 
 ## Cursor Cloud specific instructions
 

--- a/balancirk_update.xml
+++ b/balancirk_update.xml
@@ -337,6 +337,7 @@
 			<downloadurl type="full"
 				format="zip">https://github.com/kriscox/Joomla-extension-balancirk/releases/download/1.3.19/pkg_balancirk.zip</downloadurl>
 		</downloads>
+		<sha256>af3d7e652e6f068a48a6dd05bd1326e409ba88e2d4d78f74efdce4d32138b2b3</sha256>
 		<maintainer>CoCoCo</maintainer>
 		<maintainerurl>http://www.cococo.be</maintainerurl>
 		<targetplatform name="joomla"

--- a/scripts/set-update-checksum.sh
+++ b/scripts/set-update-checksum.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Insert or replace <sha256> for a given package version in balancirk_update.xml.
+#
+# Usage: scripts/set-update-checksum.sh <version> <sha256> [update-xml-path]
+# Example: scripts/set-update-checksum.sh 1.3.19 "$(sha256sum pkg_balancirk.zip | cut -d' ' -f1)"
+
+set -eu
+
+VERSION=${1:-}
+SHA256=${2:-}
+UPDATE_XML=${3:-balancirk_update.xml}
+
+if [ -z "$VERSION" ] || [ -z "$SHA256" ]; then
+    echo "Usage: $0 <version> <sha256> [update-xml-path]" >&2
+    exit 1
+fi
+
+case "$SHA256" in
+    *[!0-9a-fA-F]* | "")
+        echo "Invalid sha256 (expected hex): $SHA256" >&2
+        exit 1
+        ;;
+esac
+
+# Normalize to lowercase (Joomla compares case-insensitively but stores lowercase).
+SHA256=$(printf '%s' "$SHA256" | tr 'A-F' 'a-f')
+
+if [ ! -f "$UPDATE_XML" ]; then
+    echo "Update XML not found: $UPDATE_XML" >&2
+    exit 1
+fi
+
+python3 - "$VERSION" "$SHA256" "$UPDATE_XML" <<'PY'
+import re
+import sys
+
+version, sha256, path = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path, encoding="utf-8").read()
+
+# Match the <update>...</update> block that contains this exact <version>.
+pattern = re.compile(
+    r"(<update>\s*"
+    r"(?:(?!</update>).)*?"
+    r"<version>" + re.escape(version) + r"</version>"
+    r"(?:(?!</update>).)*?"
+    r"</update>)",
+    re.DOTALL,
+)
+
+match = pattern.search(text)
+if not match:
+    raise SystemExit(f"No <update> block found for version {version} in {path}")
+
+block = match.group(1)
+
+sha_tag = f"<sha256>{sha256}</sha256>"
+if re.search(r"<sha256>[^<]*</sha256>", block):
+    block = re.sub(r"<sha256>[^<]*</sha256>", sha_tag, block, count=1)
+elif "</downloads>" in block:
+    block = block.replace("</downloads>", f"</downloads>\n\t\t{sha_tag}", 1)
+else:
+    # Fallback: place before </update>
+    block = block.replace("</update>", f"\t\t{sha_tag}\n\t</update>", 1)
+
+text = text[: match.start(1)] + block + text[match.end(1) :]
+open(path, "w", encoding="utf-8", newline="\n").write(text)
+print(f"Set sha256 for {version} in {path}")
+PY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Documents package/test/release conventions in `AGENTS.md` so agents do not rediscover them each run.

- Test installs use only `pkg_balancirk.zip`
- Rebuild without version bump for test packages
- Version bumps + changelog/update feed only on release
- Changelog entries in English
- Master: squash-merge PR, then tag for GitHub Actions release
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f857429-9651-4a8c-b042-8ffd3e50cf89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f857429-9651-4a8c-b042-8ffd3e50cf89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

